### PR TITLE
feat!: Require encoding option to avoid inspecting chunks for UTF-8 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ var concat = require('concat-stream');
 var removeBOM = require('remove-bom-stream');
 
 fs.createReadStream('utf8-file-with-bom.txt')
-  .pipe(removeBOM())
+  .pipe(removeBOM('utf-8'))
   .pipe(
     concat(function (result) {
       // result won't have a BOM
@@ -28,9 +28,9 @@ fs.createReadStream('utf8-file-with-bom.txt')
 
 ## API
 
-### `removeBOM()`
+### `removeBOM(encoding)`
 
-Returns a `through2` stream that will remove a BOM, given the data is a UTF8 Buffer with a BOM at the beginning. If the data is not UTF8 or does not have a BOM, the data is not changed and this becomes a normal passthrough stream.
+Returns a `through2` stream that will remove a BOM, if the argument `encoding` is `'utf-8'` and the given data is a UTF8 Buffer with a BOM at the beginning. If the `encoding` is not `'utf-8'` or does not have a BOM, the data is not changed and this becomes a normal passthrough stream.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,15 @@
 var through = require('through2');
 var TextDecoder = require('util').TextDecoder;
 
+var BOM = Buffer.from([0xEF, 0xBB, 0xBF], 'utf-8');
+
 function removeBomStream(encoding) {
   encoding = (encoding || '').toLowerCase();
   var isUTF8 = (encoding === 'utf-8' || encoding === 'utf8');
+
+  if (!isUTF8) {
+    return through();
+  }
 
   // Only used if encoding is UTF-8
   var decoder = new TextDecoder('utf-8', { ignoreBOM: false });
@@ -15,23 +21,33 @@ function removeBomStream(encoding) {
   return through(onChunk);
 
   function onChunk(data, _, cb) {
-    if (state === 1 || !isUTF8) {
+    if (state === 1) {
       cb(null, data);
-    } else {
-      try {
-        state = -1;
+      return;
+    }
 
-        var chunk = decoder.decode(data, { stream: true });
+    try {
+      state = -1;
 
-        // The first time we have data after a decode, it should have already removed the BOM
-        if (chunk !== '') {
-          state = 1
+      var chunk = decoder.decode(data, { stream: true });
+
+      // The first time we have data after a decode, it should have already removed the BOM
+      if (chunk !== '') {
+        chunk += decoder.decode(); // end of stream mode and clear inner buffer.
+
+        var buffer = Buffer.from(chunk, 'utf-8');
+
+        // Node<=v11, TextDecoder#decode returns a BOM if it receives a BOM separately.
+        if (BOM.compare(buffer) !== 0) {
+          state = 1;
+          cb(null, buffer);
+          return;
         }
-
-        cb(null, Buffer.from(chunk, encoding));
-      } catch (err) {
-        cb(err);
       }
+
+      cb();
+    } catch (err) {
+      cb(err);
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var through = require('through2');
 var TextDecoder = require('util').TextDecoder;
 
-var BOM = Buffer.from([0xEF, 0xBB, 0xBF], 'utf-8');
+var BOM = '\ufeff';
 
 function removeBomStream(encoding) {
   encoding = (encoding || '').toLowerCase();
@@ -35,12 +35,12 @@ function removeBomStream(encoding) {
       if (chunk !== '') {
         chunk += decoder.decode(); // end of stream mode and clear inner buffer.
 
-        var buffer = Buffer.from(chunk, 'utf-8');
-
         // Node<=v12, TextDecoder#decode returns a BOM if it receives a BOM separately.
         // Ref https://github.com/nodejs/node/pull/30132
-        if (BOM.compare(buffer) !== 0) {
+        if (chunk !== BOM) {
           state = 1;
+          var buffer = Buffer.from(chunk, 'utf-8');
+
           cb(null, buffer);
           return;
         }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ function removeBomStream(encoding) {
 
         var buffer = Buffer.from(chunk, 'utf-8');
 
-        // Node<=v11, TextDecoder#decode returns a BOM if it receives a BOM separately.
+        // Node<=v12, TextDecoder#decode returns a BOM if it receives a BOM separately.
+        // Ref https://github.com/nodejs/node/pull/30132
         if (BOM.compare(buffer) !== 0) {
           state = 1;
           cb(null, buffer);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
 
 var through = require('through2');
-var removeBom = require('remove-bom-buffer');
+var isUTF8 = require('is-utf8');
+var TextDecoder = require('util').TextDecoder;
+
+var removeBom = new TextDecoder('utf-8', { ignoreBOM: false });
 
 function removeBomStream() {
   var state = 0; // 0:Not removed, -1:In removing, 1:Already removed
@@ -14,7 +17,10 @@ function removeBomStream() {
 
     buffer = null;
 
-    return removeBom(data);
+    if (isUTF8(data)) {
+      return removeBom.decode(data);
+    }
+    return data;
   }
 
   function onChunk(data, enc, cb) {

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function removeBomStream(encoding) {
   encoding = (encoding || '').toLowerCase();
   var isUTF8 = (encoding === 'utf-8' || encoding === 'utf8');
 
+  // Needed due to https://github.com/nodejs/node/pull/42779
   if (!isUTF8) {
     return through();
   }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var through = require('through2');
-var isUTF8 = require('is-utf8');
 var TextDecoder = require('util').TextDecoder;
 
 var removeBom = new TextDecoder('utf-8', { ignoreBOM: false });
 
-function removeBomStream() {
+function removeBomStream(encoding) {
+  encoding = (encoding || '').toLowerCase();
+  var isUtf8 = (encoding === 'utf-8' || encoding === 'utf8');
+
   var state = 0; // 0:Not removed, -1:In removing, 1:Already removed
   var buffer = Buffer.alloc(0);
 
@@ -17,7 +19,7 @@ function removeBomStream() {
 
     buffer = null;
 
-    if (isUTF8(data)) {
+    if (isUtf8) {
       return removeBom.decode(data);
     }
     return data;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "remove-bom-buffer": "^3.0.0",
+    "is-utf8": "^0.2.1",
     "through2": "^4.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "is-utf8": "^0.2.1",
     "through2": "^4.0.2"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ describe('removeBomStream', function () {
     }
 
     pipe(
-      [fs.createReadStream(filepath), removeBomStream(), concat(assert)],
+      [fs.createReadStream(filepath), removeBomStream('utf-8'), concat(assert)],
       done
     );
   });
@@ -33,7 +33,7 @@ describe('removeBomStream', function () {
     var filepath = path.join(__dirname, './fixtures/test.txt');
     var fileContent = fs.readFileSync(filepath, 'utf-8');
 
-    var rmBom = removeBomStream();
+    var rmBom = removeBomStream('utf8');
     var output = '';
     rmBom.on('data', function (d) {
       output += d.toString();
@@ -55,7 +55,7 @@ describe('removeBomStream', function () {
     }
 
     pipe(
-      [fs.createReadStream(filepath), removeBomStream(), concat(assert)],
+      [fs.createReadStream(filepath), removeBomStream('UTF-8'), concat(assert)],
       done
     );
   });
@@ -73,7 +73,7 @@ describe('removeBomStream', function () {
       [
         fs.createReadStream(filepath),
         chunker(1),
-        removeBomStream(),
+        removeBomStream('UTF8'),
         concat(assert),
       ],
       done
@@ -92,7 +92,7 @@ describe('removeBomStream', function () {
     }
 
     pipe(
-      [fs.createReadStream(filepath), removeBomStream(), concat(assert)],
+      [fs.createReadStream(filepath), removeBomStream('UTF-8'), concat(assert)],
       done
     );
   });
@@ -101,7 +101,7 @@ describe('removeBomStream', function () {
     var filepath = path.join(__dirname, './fixtures/bom-utf8.txt');
     var fileContent = fs.readFileSync(filepath, 'utf-8');
 
-    var rmBom = removeBomStream();
+    var rmBom = removeBomStream('utf-8');
     var output = '';
     rmBom.on('data', function (d) {
       output += d.toString();
@@ -123,7 +123,7 @@ describe('removeBomStream', function () {
     }
 
     pipe(
-      [fs.createReadStream(filepath), removeBomStream(), concat(assert)],
+      [fs.createReadStream(filepath), removeBomStream('utf-16be'), concat(assert)],
       done
     );
   });
@@ -138,7 +138,7 @@ describe('removeBomStream', function () {
     }
 
     pipe(
-      [fs.createReadStream(filepath), removeBomStream(), concat(assert)],
+      [fs.createReadStream(filepath), removeBomStream('utf-16be'), concat(assert)],
       done
     );
   });
@@ -153,7 +153,7 @@ describe('removeBomStream', function () {
     }
 
     pipe(
-      [fs.createReadStream(filepath), removeBomStream(), concat(assert)],
+      [fs.createReadStream(filepath), removeBomStream('utf-16le'), concat(assert)],
       done
     );
   });


### PR DESCRIPTION
This PR is to fix the issue #5.

This PR changes that:
- Removes the dependency on `remove-bom-buffer`.
- Adds the substitute code of `remove-bom-buffer`.
- Uses `Buffer.isBuffer` instead of `is-buffer` module.
- Adds the direct dependency on `is-utf8`, which is used in `remove-bom-buffer`.


(fixes #5)